### PR TITLE
fix bug when xml ends with \n \n\n \n\n\n ...

### DIFF
--- a/addons/godot_xml/xml.gd
+++ b/addons/godot_xml/xml.gd
@@ -150,6 +150,7 @@ static func _parse(xml: PackedByteArray) -> XMLDocument:
 
 static func _make_node(queue: Array, parser: XMLParser):
 	var node_type = parser.get_node_type()
+
 	match node_type:
 		XMLParser.NODE_ELEMENT:
 			return _make_node_element(parser)

--- a/addons/godot_xml/xml.gd
+++ b/addons/godot_xml/xml.gd
@@ -128,14 +128,12 @@ static func _parse(xml: PackedByteArray) -> XMLDocument:
 		if node == null:
 			continue
 
-		var node_type = parser.get_node_type()
-		if node_type == XMLParser.NODE_ELEMENT_END and (queue.is_empty() || queue.back().name != node.name):
-			continue
-
 		if len(queue) == 0:
 			doc.root = node
 			queue.append(node)
 		else:
+			var node_type = parser.get_node_type()
+
 			if node_type == XMLParser.NODE_TEXT:
 				continue
 
@@ -152,11 +150,13 @@ static func _parse(xml: PackedByteArray) -> XMLDocument:
 
 static func _make_node(queue: Array, parser: XMLParser):
 	var node_type = parser.get_node_type()
-
+	var node_name = parser.get_node_name()
 	match node_type:
 		XMLParser.NODE_ELEMENT:
 			return _make_node_element(parser)
 		XMLParser.NODE_ELEMENT_END:
+			if queue.is_empty() || queue.back().name != node_name:
+				return
 			return _make_node_element_end(parser)
 		XMLParser.NODE_TEXT:
 			if queue.is_empty():

--- a/addons/godot_xml/xml.gd
+++ b/addons/godot_xml/xml.gd
@@ -155,7 +155,7 @@ static func _make_node(queue: Array, parser: XMLParser):
 		XMLParser.NODE_ELEMENT:
 			return _make_node_element(parser)
 		XMLParser.NODE_ELEMENT_END:
-			if queue.is_empty() || queue.back().name != node_name:
+			if queue.is_empty() or queue.back().name != node_name:
 				return
 			return _make_node_element_end(parser)
 		XMLParser.NODE_TEXT:

--- a/addons/godot_xml/xml.gd
+++ b/addons/godot_xml/xml.gd
@@ -128,12 +128,14 @@ static func _parse(xml: PackedByteArray) -> XMLDocument:
 		if node == null:
 			continue
 
+		var node_type = parser.get_node_type()
+		if node_type == XMLParser.NODE_ELEMENT_END and (queue.is_empty() || queue.back().name != node.name):
+			continue
+
 		if len(queue) == 0:
 			doc.root = node
 			queue.append(node)
 		else:
-			var node_type = parser.get_node_type()
-
 			if node_type == XMLParser.NODE_TEXT:
 				continue
 
@@ -157,6 +159,8 @@ static func _make_node(queue: Array, parser: XMLParser):
 		XMLParser.NODE_ELEMENT_END:
 			return _make_node_element_end(parser)
 		XMLParser.NODE_TEXT:
+			if queue.is_empty():
+				return
 			_attach_node_data(queue.back(), parser)
 			return
 

--- a/addons/godot_xml/xml.gd
+++ b/addons/godot_xml/xml.gd
@@ -150,13 +150,10 @@ static func _parse(xml: PackedByteArray) -> XMLDocument:
 
 static func _make_node(queue: Array, parser: XMLParser):
 	var node_type = parser.get_node_type()
-	var node_name = parser.get_node_name()
 	match node_type:
 		XMLParser.NODE_ELEMENT:
 			return _make_node_element(parser)
 		XMLParser.NODE_ELEMENT_END:
-			if queue.is_empty() or queue.back().name != node_name:
-				return
 			return _make_node_element_end(parser)
 		XMLParser.NODE_TEXT:
 			if queue.is_empty():


### PR DESCRIPTION
Fix the bug when the xml ends with one or more newline characters.
It may be a bug of godot, when the xml ends with a newline character, paser.read() will get a wrong NODE_ELEMENT_END. This causes the doc to be empty.
When the xml ends with multiple newline characters, paser.read() will get a NODE_TEXT, but the queue is empty at this time, so queue.back() will get null.