### PR TITLE
feat: Dotted child access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ library.xml
 
 # Keep the addon icon
 !addons/godot_xml/icon.svg
+!addons/godot_xml/icon.png

--- a/addons/godot_xml/xml_node.gd
+++ b/addons/godot_xml/xml_node.gd
@@ -16,6 +16,8 @@ var standalone: bool = false
 ## XML node's children.
 var children: Array[XMLNode] = []
 
+var _node_props = null  # Array[String]
+
 func _to_string():
 	return "<XMLNode name=%s attributes=%s content=%s standalone=%s children=%s>" % [
 		name,
@@ -24,3 +26,25 @@ func _to_string():
 		str(standalone),
 		"[...]" if len(children) > 0 else "[]"
 	]
+
+
+func _get(property: StringName):
+	if _node_props == null:
+		_initialize_node_properties()
+
+	if property not in ["name", "attributes", "content", "standalone", "children"] and property in _node_props:
+		for child in children:
+			if child.name == property:
+				return child
+
+
+func _initialize_node_properties():
+	var names_to_nodes = {}
+
+	for child in children:
+		if not child.name in names_to_nodes.keys():
+			names_to_nodes[child.name] = child
+		else:
+			names_to_nodes.erase(child.name)
+
+	_node_props = names_to_nodes.keys()


### PR DESCRIPTION
Allows accessing non-repeated node children via `parent_node.child_none_name`. In case there are multiple children with the same name attribute access still errors.