### PR TITLE
fix: Ignore non-standard content after the first root.

### DIFF
--- a/addons/godot_xml/xml.gd
+++ b/addons/godot_xml/xml.gd
@@ -118,11 +118,15 @@ static func _dump_node(node: XMLNode, closing: bool = false, beautify: bool = fa
 static func _parse(xml: PackedByteArray) -> XMLDocument:
 	var doc: XMLDocument = XMLDocument.new()
 	var queue: Array = []
+	var already_has_root = false
 
 	var parser: XMLParser = XMLParser.new()
 	parser.open_buffer(xml)
 
 	while parser.read() != ERR_FILE_EOF:
+		if already_has_root and queue.is_empty():
+			break  # Multiple roots are not supported (and are also not valid).
+
 		var node: XMLNode = _make_node(queue, parser)
 
 		if node == null:
@@ -131,6 +135,7 @@ static func _parse(xml: PackedByteArray) -> XMLDocument:
 		if len(queue) == 0:
 			doc.root = node
 			queue.append(node)
+			already_has_root = true
 		else:
 			var node_type = parser.get_node_type()
 


### PR DESCRIPTION
Multiple root elements are not valid per standard. If the user needs to, they can trivially wrap multiple roots with a single parent.