### PR TITLE
refactor: Add basic error handling, properly document code, refactor converters, remove useless checks.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2023-present ItsAleph
+Copyright 2023-present elenakrittik
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/README.md
+++ b/README.md
@@ -11,19 +11,25 @@ This addon adds support for manipulating XML data in Godot 4 with ease.
 - Access uniquely named children of nodes as if they were regular attributes (works in the editor too!);
 - Decent error messages for when the input is malformed*.
 
-\* `XMLParser`, Godot's native, low-level XML parser that this addon works on top of, or, more specifically,
-`irrXML` (on which it is based), always assumes input to be trusted and valid, and therefore lacks both
-adequate error handling and adequate security measures. In case of error handling addon currently
-implements a few workarounds that eliminate *known* godot bugs; in case of security we can't do anything
-unfortunately. Due to the above and our intention for this plugin to be usable in as much cases as possible,
-this addon will soon migrate to a custom, more modern XML library like Expat.
+<details>
+  <summary>*Future plans</summary>
 
-Related issues on Godot's tracker:
-- https://github.com/godotengine/godot/issues/72517
-- https://github.com/godotengine/godot/issues/51380
-- https://github.com/godotengine/godot/issues/81896
-- https://github.com/godotengine/godot/issues/51622
-- https://github.com/godotengine/godot/issues/81896#issuecomment-1731320027
+  `XMLParser`, Godot's native, low-level XML parser that this addon works on top of, or, more specifically,
+  `irrXML` (on which `XMLParser` is based), always assumes input to be trusted and valid, and therefore lacks both
+  adequate error handling and adequate security measures. In case of error handling addon currently
+  implements a few workarounds that eliminate *known* godot bugs, but still cannot handle syntactically invalid
+  input; in case of security we can't do anything unfortunately. Due to the above and our intention for this
+  plugin to be usable in as much cases as possible, this addon will soon migrate to a custom, more modern XML
+  library like Expat.
+
+  Related issues on Godot's tracker:
+  - https://github.com/godotengine/godot/issues/72517
+  - https://github.com/godotengine/godot/issues/51380
+  - https://github.com/godotengine/godot/issues/81896
+  - https://github.com/godotengine/godot/issues/51622
+  - https://github.com/godotengine/godot/issues/81896#issuecomment-1731320027
+
+</details>
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,25 @@ This addon adds support for manipulating XML data in Godot 4 with ease.
 
 ## Features
 
+- Pure-Godot - everything is done using built-in `XMLParser` and does not rely on external bindings*;
 - Loading and dumping XML data into/from a convenient class-based format;
 - Beautifying XML;
-- Converting XML into dictionaries.
+- Converting XML into dictionaries;
+- Access uniquely named children of nodes as if they were regular attributes (works in the editor too!);
+- Decent error messages for when the input is malformed*.
+
+\* `XMLParser`, Godot's native, low-level XML parser that this addon works on top of, or, more specifically,
+`irrXML` (on which it is based), always assumes input to be trusted and valid, and therefore lacks both
+adequate error handling and adequate security measures. In case of error handling addon currently
+assumes that `XMLParser` does not have any bugs (which is false); in case of security we can't do anything
+unfortunately. Due to the above and our intention for this plugin to be usable in as much cases as possible, this addon will soon migrate to a custom, more modern XML library like Expat.
+
+Related issues on Godot's tracker:
+- https://github.com/godotengine/godot/issues/72517
+- https://github.com/godotengine/godot/issues/51380
+- https://github.com/godotengine/godot/issues/81896
+- https://github.com/godotengine/godot/issues/51622
+- https://github.com/godotengine/godot/issues/81896#issuecomment-1731320027
 
 ## Installation
 
@@ -17,13 +33,9 @@ Search for the "GodotXML" addon on the asset library ([link](https://godotengine
 All functions and attributes that are meant for use by you do not have `_` before their name
 and are also listed before any internal function.
 
-All other functions and attributes are **not meant** to be used by you, though you
-can edit them as you like thanks to the license.
+All other functions and attributes are **not meant** to be used by you, though of course
+you can edit them as you like.
 
 ## Roadmap
-
-- [ ] Allow dotted access for XMLNode's children;
-
-- [ ] Automatic detection and conversion of nodes' content type;
 
 - [ ] Setup automated tests.

--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ This addon adds support for manipulating XML data in Godot 4 with ease.
 \* `XMLParser`, Godot's native, low-level XML parser that this addon works on top of, or, more specifically,
 `irrXML` (on which it is based), always assumes input to be trusted and valid, and therefore lacks both
 adequate error handling and adequate security measures. In case of error handling addon currently
-assumes that `XMLParser` does not have any bugs (which is false); in case of security we can't do anything
-unfortunately. Due to the above and our intention for this plugin to be usable in as much cases as possible, this addon will soon migrate to a custom, more modern XML library like Expat.
+implements a few workarounds that eliminate *known* godot bugs; in case of security we can't do anything
+unfortunately. Due to the above and our intention for this plugin to be usable in as much cases as possible,
+this addon will soon migrate to a custom, more modern XML library like Expat.
 
 Related issues on Godot's tracker:
 - https://github.com/godotengine/godot/issues/72517

--- a/addons/godot_xml/xml.gd
+++ b/addons/godot_xml/xml.gd
@@ -4,213 +4,211 @@
 class_name XML extends RefCounted
 
 
-## Specifies the type of a node.
-enum XMLNodeType {
-	XML_NODE_ELEMENT_START, ## Start node ([code]<myroot>[/code])
-	XML_NODE_ELEMENT_END, ## End node ([code]</myroot>[/code])
-	XML_NODE_COMMENT, ## Comment node ([code]<!-- My comment -->[/code])
-}
-
-
 ## Parses file content as XML into [XMLDocument].
 ## The file at a specified [code]path[/code] [b]must[/b] be readable.
-## File content [b]must[/b] be a valid XML document.
 static func parse_file(path: String) -> XMLDocument:
-	var file = FileAccess.open(path, FileAccess.READ)
-	var xml: PackedByteArray = file.get_as_text().to_utf8_buffer()
-	file = null
+    var file = FileAccess.open(path, FileAccess.READ)
+    var xml: PackedByteArray = file.get_as_text().to_utf8_buffer()
+    file = null
 
-	return _parse(xml)
+    return _parse(xml)
 
 
 ## Parses string as XML into [XMLDocument].
-## String content [b]must[/b] be a valid XML document.
 static func parse_str(xml: String) -> XMLDocument:
-	return _parse(xml.to_utf8_buffer())
+    return _parse(xml.to_utf8_buffer())
 
 
 ## Parses byte buffer as XML into [XMLDocument].
-## Buffer content [b]must[/b] be a valid XML document.
 static func parse_buffer(xml: PackedByteArray) -> XMLDocument:
-	return _parse(xml)
+    return _parse(xml)
 
 
 ## Dumps [param document] to the specified file.
 ## The file at a specified [code]path[/code] [b]must[/b] be writeable.
-## Set [param beautify] to [code]true[/code] if you want indented output.
-static func dump_file(path: String, document: XMLDocument, beautify: bool = false):
-	var file = FileAccess.open(path, FileAccess.WRITE)
-	var xml: String = dump_str(document, beautify)
-	file.store_string(xml)
-	file = null
+## Set [param pretty] to [code]true[/code] if you want indented output.
+## If [param pretty] is [code]true[/code], [param indent_level] controls the initial indentation level.
+## If [param pretty] is [code]true[/code], [param indent_length] controls the length of a single indentation level.
+static func dump_file(path: String, document: XMLDocument,
+    pretty: bool = false,
+    indent_level: int = 0,
+    indent_length: int = 2,
+):
+    var file = FileAccess.open(path, FileAccess.WRITE)
+    var xml: String = dump_str(document, pretty, indent_level, indent_length)
+    file.store_string(xml)
+    file = null
 
 
 ## Dumps [param document] to a [PackedByteArray].
-## Set [param beautify] to [code]true[/code] if you want indented output.
-static func dump_buffer(document: XMLDocument, beautify: bool = false) -> PackedByteArray:
-	return dump_str(document, beautify).to_utf8_buffer()
+## Set [param pretty] to [code]true[/code] if you want indented output.
+## If [param pretty] is [code]true[/code], [param indent_level] controls the initial indentation level.
+## If [param pretty] is [code]true[/code], [param indent_length] controls the length of a single indentation level.
+static func dump_buffer(
+    document: XMLDocument,
+    pretty: bool = false,
+    indent_level: int = 0,
+    indent_length: int = 2,
+) -> PackedByteArray:
+    return dump_str(document, pretty, indent_level, indent_length).to_utf8_buffer()
 
 
 ## Dumps [param document] to [String].
-## Set [param beautify] to [code]true[/code] if you want indented output.
-static func dump_str(document: XMLDocument, beautify: bool = false) -> String:
-	return _dump(document, beautify)
+## Set [param pretty] to [code]true[/code] if you want indented output.
+## If [param pretty] is [code]true[/code], [param indent_level] controls the initial indentation level.
+## If [param pretty] is [code]true[/code], [param indent_length] controls the length of a single indentation level.
+static func dump_str(document: XMLDocument,
+    pretty: bool = false,
+    indent_level: int = 0,
+    indent_length: int = 2,
+) -> String:
+    if indent_level < 0:
+        push_warning("indent_level must be >= 0")
+        indent_level = 0
 
+    if indent_length < 0:
+        push_warning("indent_length must be >= 0")
+        indent_length = 0
+    
+    return document.root._dump() if not pretty else document.root._dump_pretty(indent_level, indent_length)
 
-static func _dump(document: XMLDocument, beautify: bool = false):
-	if not beautify:
-		return _dump_compact(document.root)
-	else:
-		return _dump_beautifully(document.root)
-
-
-static func _dump_compact(node: XMLNode):
-	var out: String = ""
-
-	out += _dump_node(node)
-	
-	for child in node.children:
-		out += _dump_compact(child)
-
-	if not node.standalone:
-		out += _dump_node(node, true)
-
-	return out
-
-
-static func _dump_beautifully(node: XMLNode, indent: int = 0):
-	var out: String = ""
-
-	out += _beauty(_dump_node(node, false, true), indent)
-
-	for child in node.children:
-		out += _dump_beautifully(child, indent + 4)
-
-	if not node.standalone:
-		out += _beauty(_dump_node(node, true, true), indent)
-
-	return out
-
-
-static func _beauty(string: String, i: int) -> String:
-	return " ".repeat(i) + string + "\n"
-
-
-static func _dump_node(node: XMLNode, closing: bool = false, beautify: bool = false):
-	var attrs: Array[String] = []
-
-	for attr in node.attributes:
-		attrs.append(attr + "=\"" + node.attributes.get(attr) + "\"")
-	
-	var attrstr = " ".join(attrs)
-
-	if node.standalone:
-		var space = " " if beautify else ""
-		return "<%s %s%s/>" % [node.name, attrstr, space]
-	else:
-		if closing:
-			return "</%s>" % node.name
-		else:
-			var space = " " if not attrstr.is_empty() else ""
-			return "<%s%s%s>%s" % [node.name, space, attrstr, node.content]
 
 
 static func _parse(xml: PackedByteArray) -> XMLDocument:
-	var doc: XMLDocument = XMLDocument.new()
-	var queue: Array = []
+    xml = _cleanup_double_blankets(xml)  # see comment in function body
 
-	var parser: XMLParser = XMLParser.new()
-	parser.open_buffer(xml)
+    var doc: XMLDocument = XMLDocument.new()
+    var queue: Array = []  # queue of unclosed tags
 
-	while parser.read() != ERR_FILE_EOF:
-		var node: XMLNode = _make_node(queue, parser)
+    var parser: XMLParser = XMLParser.new()
+    parser.open_buffer(xml)
 
-		if node == null:
-			continue
+    while parser.read() != ERR_FILE_EOF:
+        var node: XMLNode = _make_node(queue, parser)
 
-		if len(queue) == 0:
-			doc.root = node
-			queue.append(node)
-		else:
-			var node_type = parser.get_node_type()
+        # if node type is NODE_TEXT, there will be no node, so we just skip
+        if node == null:
+            continue
 
-			if node_type == XMLParser.NODE_TEXT:
-				continue
+        # if we just started, we set our first node as root and initialize queue
+        if len(queue) == 0:
+            doc.root = node
+            queue.append(node)
+        else:
+            var node_type = parser.get_node_type()
 
-			if node.standalone and not node_type == XMLParser.NODE_ELEMENT_END:
-				queue.back().children.append(node)
-			elif node_type == XMLParser.NODE_ELEMENT_END and not node.standalone:
-				var last = queue.pop_back()
+            # below, `queue.back().children.append(...)` means:
+            # - take the last node
+            # - since we are inside that unclosed node, all non-closing nodes we get are it's children
+            # - therefore, we access .children and append our non-closing node to them
 
-				if node.name != last.name:
-					push_error(
-						"Invalid closing tag: started with %s but ended with %s." % [last.name, node.name]\
-						+ "Stopping. Output may be invalid or incomplete."
-					)
-					break
+            # hopefully speaks for itself
+            if node.standalone:
+                queue.back().children.append(node)
 
-				if queue.is_empty():
-					break  # Ignore anything after the root is closed (multiple roots for example)
-			else:
-				queue.back().children.append(node)
-				queue.append(node)
-	
-	return doc
+            # same here
+            elif node_type == XMLParser.NODE_ELEMENT_END:
+                var last = queue.pop_back()  # get-remove last unclosed node
+
+                # if we got a closing node, but it's name is not the same as opening one, it's an error
+                if node.name != last.name:
+                    push_error(
+                        "Invalid closing tag: started with %s but ended with %s. Ignoring (output may be incorrect)." % [last.name, node.name]
+                    )
+                    # instead of break'ing here we just continue, since often invalid name is just a typo
+                    continue
+
+                # we just closed a node, so if the queue is empty we stop parsing (effectively ignoring
+                # anything past the first root). this is done to prevent latter roots overwriting former
+                # ones in case when there's more than one root (invalid per standard, but still used in
+                # some documents). we do not natively support multiple roots (and will not, please do not
+                # open PRs for that), but if the user really needs to, it is trivial to wrap the input with
+                # another "housing" node.
+                if queue.is_empty():
+                    break
+
+            # opening node
+            else:
+                queue.back().children.append(node)
+                queue.append(node)  # move into our node's body
+
+    # if parsing ended, but there are still unclosed nodes, we report it
+    if not queue.is_empty():
+        queue.reverse()
+        var names = []
+
+        for node in queue:
+            names.append(node.name)
+
+        push_error("The following nodes were not closed: %s" % ", ".join(names))
+
+    return doc
 
 
 static func _make_node(queue: Array, parser: XMLParser):
-	var node_type = parser.get_node_type()
+    var node_type = parser.get_node_type()
 
-	match node_type:
-		XMLParser.NODE_ELEMENT:
-			return _make_node_element(parser)
-		XMLParser.NODE_ELEMENT_END:
-			return _make_node_element_end(parser)
-		XMLParser.NODE_TEXT:
-			if queue.is_empty():
-				return
-			_attach_node_data(queue.back(), parser)
-			return
-
-	#print(node_type)
-	#print(parser.get_node_data())
-	#print(parser.get_node_name())
+    match node_type:
+        XMLParser.NODE_ELEMENT:
+            return _make_node_element(parser)
+        XMLParser.NODE_ELEMENT_END:
+            return _make_node_element_end(parser)
+        XMLParser.NODE_TEXT:
+            # ignores blank text before root node; it is easier this way, trust me
+            if queue.is_empty():
+                return
+            _attach_node_data(queue.back(), parser)
+            return
 
 
 static func _make_node_element(parser: XMLParser):
-	var node: XMLNode = XMLNode.new()
+    var node: XMLNode = XMLNode.new()
 
-	node.name = parser.get_node_name()
-	node.attributes = _get_attributes(parser)
-	node.content = ""
-	node.standalone = parser.is_empty()
-	node.children = []
+    node.name = parser.get_node_name()
+    node.attributes = _get_attributes(parser)
+    node.content = ""
+    node.standalone = parser.is_empty()  # see .is_empty() docs
+    node.children = []
 
-	return node
+    return node
 
 
 static func _make_node_element_end(parser: XMLParser) -> XMLNode:
-	var node: XMLNode = XMLNode.new()
+    var node: XMLNode = XMLNode.new()
 
-	node.name = parser.get_node_name()
-	node.attributes = {}
-	node.content = ""
-	node.standalone = false
-	node.children = []
+    node.name = parser.get_node_name()
+    node.attributes = {}
+    node.content = ""
+    node.standalone = false  # standalone nodes are always NODE_ELEMENT
+    node.children = []
 
-	return node
+    return node
 
 
 static func _attach_node_data(node: XMLNode, parser: XMLParser) -> void:
-	if node.content.is_empty():
-		node.content = parser.get_node_data().strip_edges().lstrip(" ").rstrip(" ")
+    if node.content.is_empty():
+        # XMLParser treats even blank stuff between nodes as NODE_TEXT, which is at least incorrect
+        # therefore we strip blankets, resulting in only actual content slipping into .content
+        node.content = parser.get_node_data().strip_edges().lstrip(" ").rstrip(" ")
 
 
 static func _get_attributes(parser: XMLParser) -> Dictionary:
-	var attrs: Dictionary = {}
-	var attr_count: int = parser.get_attribute_count()
+    var attrs: Dictionary = {}
+    var attr_count: int = parser.get_attribute_count()
 
-	for attr_idx in range(attr_count):
-		attrs[parser.get_attribute_name(attr_idx)] = parser.get_attribute_value(attr_idx)
-	
-	return attrs
+    for attr_idx in range(attr_count):
+        attrs[parser.get_attribute_name(attr_idx)] = parser.get_attribute_value(attr_idx)
+
+    return attrs
+
+
+static func _cleanup_double_blankets(xml: PackedByteArray) -> PackedByteArray:
+    # XMLParser is again "incorrect" and duplicates nodes due to double blank escapes
+    # https://github.com/godotengine/godot/issues/81896#issuecomment-1731320027
+    var cleaned: PackedByteArray = PackedByteArray()
+
+    for byte in xml:
+        if byte not in [9, 10, 13]: # [\t, \n, \r]
+            cleaned.append(byte)
+
+    return cleaned

--- a/addons/godot_xml/xml.gd
+++ b/addons/godot_xml/xml.gd
@@ -140,8 +140,15 @@ static func _parse(xml: PackedByteArray) -> XMLDocument:
 			if node.standalone and not node_type == XMLParser.NODE_ELEMENT_END:
 				queue.back().children.append(node)
 			elif node_type == XMLParser.NODE_ELEMENT_END and not node.standalone:
-				queue.pop_back()
-				
+				var last = queue.pop_back()
+
+				if node.name != last.name:
+					push_error(
+						"Invalid closing tag: started with %s but ended with %s." % [last.name, node.name]\
+						+ "Stopping. Output may be invalid or incomplete."
+					)
+					break
+
 				if queue.is_empty():
 					break  # Ignore anything after the root is closed (multiple roots for example)
 			else:

--- a/addons/godot_xml/xml.gd
+++ b/addons/godot_xml/xml.gd
@@ -6,6 +6,7 @@ class_name XML extends RefCounted
 
 ## Parses file content as XML into [XMLDocument].
 ## The file at a specified [code]path[/code] [b]must[/b] be readable.
+## File content [b]must[/b] be a syntactically valid XML document.
 static func parse_file(path: String) -> XMLDocument:
     var file = FileAccess.open(path, FileAccess.READ)
     var xml: PackedByteArray = file.get_as_text().to_utf8_buffer()
@@ -15,11 +16,13 @@ static func parse_file(path: String) -> XMLDocument:
 
 
 ## Parses string as XML into [XMLDocument].
+## File content [b]must[/b] be a syntactically valid XML document.
 static func parse_str(xml: String) -> XMLDocument:
     return _parse(xml.to_utf8_buffer())
 
 
 ## Parses byte buffer as XML into [XMLDocument].
+## File content [b]must[/b] be a syntactically valid XML document.
 static func parse_buffer(xml: PackedByteArray) -> XMLDocument:
     return _parse(xml)
 

--- a/addons/godot_xml/xml_document.gd
+++ b/addons/godot_xml/xml_document.gd
@@ -4,65 +4,6 @@ class_name XMLDocument extends RefCounted
 ## The XML root node.
 var root: XMLNode
 
-## Converts this tree into a [Dictionary].
-## Set [param include_empty_fields] to [code]true[/code] if you want
-## to include fields that do not have any content (e.g., a node without
-## a single attribute or without content).
-## [param node_content_field_name] controls which field node's content is assigned to.
-func to_dict(
-	include_empty_fields: bool = false,
-	node_content_field_name: String = "__content__",
-) -> Dictionary:
-	return _to_dict(root, include_empty_fields, node_content_field_name)
-
-
-static func _to_dict(
-	node: XMLNode,
-	include_empty_fields: bool = false,
-	node_content_field_name: String = "__content__",
-) -> Dictionary:
-	var data: Dictionary = {}
-
-	if include_empty_fields:
-		data = _to_dict_all_fields(node)
-		data.children = []
-	else:
-		data =_to_dict_least_fields(node)
-
-	data[node_content_field_name] = node.content
-
-	for child in node.children:
-		if not data.has("children"):
-			data.children = []
-
-		data.children.append(_to_dict(child))
-
-	return data
-
-
-static func _to_dict_all_fields(node: XMLNode) -> Dictionary:
-	var data: Dictionary = {}
-
-	data.name = node.name
-	data.attributes = node.attributes
-	data.standalone = node.standalone
-
-	return data
-
-
-static func _to_dict_least_fields(node: XMLNode) -> Dictionary:
-	var data: Dictionary = {}
-
-	if not node.name.is_empty():
-		data.name = node.name
-
-	if not node.attributes.is_empty():
-		data.attributes = node.attributes
-
-	data.standalone = node.standalone
-
-	return data
-
 
 func _to_string():
-	return "<XMLDocument root=%s>" % str(root)
+    return "<XMLDocument root=%s>" % str(root)

--- a/addons/godot_xml/xml_node.gd
+++ b/addons/godot_xml/xml_node.gd
@@ -1,4 +1,5 @@
-## Represents an XML element (AKA XML node).
+## Represents an XML element (AKA XML node). Hint: if there's only single child with
+## the same name, you can access it via [code]this_node.my_child_name[/code]!
 class_name XMLNode extends RefCounted
 
 ## XML node name.
@@ -18,56 +19,137 @@ var children: Array[XMLNode] = []
 
 var _node_props = null  # Array[String]
 
+
+## Converts this node (and all of it's children) into a [Dictionary].
+## Name is set directly as [code]__name__: name[/code].
+## Content is set directly as [code]__content__: content[/code].
+## Attributes are set directly as [code]attrs: {attr_name: attr_value}[/code].
+## Children are set directly as [code]children: {child_name: child_dict}[/code].
+func to_dict() -> Dictionary:
+    var output = {}
+
+    output["__name__"] = name
+    output["__content__"] = content
+    output["attrs"] = attributes
+
+    var children_dict = {}
+    for child in children:
+        children_dict[child.name] = child.to_dict()
+
+    output["children"] = children_dict
+
+    return output
+
+
 func _to_string():
-	return "<XMLNode name=%s attributes=%s content=%s standalone=%s children=%s>" % [
-		name,
-		"{...}" if len(attributes) > 0 else "{}",
-		"\"...\"" if len(content) > 0 else "\"\"",
-		str(standalone),
-		"[...]" if len(children) > 0 else "[]"
-	]
+    return "<XMLNode name=%s attributes=%s content=%s standalone=%s children=%s>" % [
+        name,
+        "{...}" if len(attributes) > 0 else "{}",
+        '"..."' if len(content) > 0 else '""',
+        str(standalone),
+        "[...]" if len(children) > 0 else "[]"
+    ]
 
 
 # Dotted access via GDScript
 func _get(property: StringName):
-	if _node_props == null:
-		_initialize_node_properties()
+    if _node_props == null:
+        _initialize_node_properties()
 
-	if property not in ["name", "attributes", "content", "standalone", "children"] and property in _node_props:
-		for child in children:
-			if child.name == property:
-				return child
+    if property not in ["name", "attributes", "content", "standalone", "children"] and property in _node_props:
+        for child in children:
+            if child.name == property:
+                return child
 
 
 # Dotted access via editor
 func _get_property_list():
-	var props = []
+    var props = []
 
-	if _node_props == null:
-		_initialize_node_properties()
-	
-	for child_name in _node_props:
-		var child = _get(child_name)
+    if _node_props == null:
+        _initialize_node_properties()
+    
+    for child_name in _node_props:
+        var child = _get(child_name)
 
-		props.append({
-			"name": child_name,
-			"type": TYPE_OBJECT,
-			"class_name": "XMLNode",
-			"usage": PROPERTY_USAGE_DEFAULT,
-			"hint": PROPERTY_HINT_NONE,
-			"hint_string": "",
-		})
-	
-	return props
+        props.append({
+            "name": child_name,
+            "type": TYPE_OBJECT,
+            "class_name": "XMLNode",
+            "usage": PROPERTY_USAGE_DEFAULT,
+            "hint": PROPERTY_HINT_NONE,
+            "hint_string": "",
+        })
+
+    return props
 
 
 func _initialize_node_properties():
-	var names_to_nodes = {}
+    var names_to_nodes = {}
 
-	for child in children:
-		if not child.name in names_to_nodes.keys():
-			names_to_nodes[child.name] = child
-		else:
-			names_to_nodes.erase(child.name)
+    for child in children:
+        if not child.name in names_to_nodes.keys():
+            names_to_nodes[child.name] = child
+        else:
+            names_to_nodes.erase(child.name)
 
-	_node_props = names_to_nodes.keys()
+    _node_props = names_to_nodes.keys()
+
+
+func _dump() -> String:
+    var template = (
+        "<{node_name}{attributes}>{content}{children}</{node_name}>"
+        if not standalone else
+        "<{node_name}{attributes}/>"
+    )
+    var attribute_string = ""
+    var children_string = ""
+
+    if not attributes.is_empty():
+        attribute_string += " "
+
+        for attribute_key in attributes:
+            var attribute_value = attributes.get(attribute_key)
+            attribute_string += '{key}="{value}"'.format({"key": attribute_key, "value": attribute_value})
+
+    for child in children:
+        children_string += child._dump()
+
+    return template.format({
+        "node_name": name,
+        "attributes": attribute_string,
+        "content": content,
+        "children": children_string,
+    })
+
+
+func _dump_pretty(indent_level: int, indent_length: int) -> String:
+        var template = (
+            "{indent}<{node_name}{attributes}>{content}{children}\n{indent}</{node_name}>"
+            if not standalone else
+            "{indent}<{node_name}{attributes}/>"
+        )
+        var indent_string = " ".repeat(indent_level * indent_length)
+        var indent_next_string = indent_string + " ".repeat(indent_length)
+        var attribute_string = ""
+        var content_string = "\n" + indent_next_string + content if not content.is_empty() else ""
+        var children_string = ""
+
+        if not attributes.is_empty():
+            attribute_string += " "
+
+            for attribute_key in attributes:
+                var attribute_value = attributes.get(attribute_key)
+                attribute_string += '{key}="{value}"'.format({"key": attribute_key, "value": attribute_value})
+    
+        for child in children:
+            children_string += "\n" + child._dump_pretty(indent_level + 1, indent_length)
+
+        return template.format({
+            "node_name": name,
+            "attributes": attribute_string,
+            "content": content_string,
+            "children": children_string,
+
+            "indent": indent_string,
+        })


### PR DESCRIPTION
Fixes #2 
Fixes #7 

- [x] Error handling
- - [x] Invalid closing tag
- - [x] Unclosed tags
- [x] Document code
- [x] Refactor dumper/beautifier
- [x] Reformat to use spaces
- [x] Refactor dict converter