### PR TITLE
Fixed loss of homonymous children on conversion to dict

### DIFF
--- a/addons/godot_xml/xml_node.gd
+++ b/addons/godot_xml/xml_node.gd
@@ -37,13 +37,10 @@ func to_dict() -> Dictionary:
     output["__content__"] = self.content
     output["__cdata__"] = self.cdata
     output["attrs"] = self.attributes
-
-    var children_dict := {}
-
-    for child in self.children:
-        children_dict[child.name] = child.to_dict()
-
-    output["children"] = children_dict
+    output["children"] = self.children.map(
+        func(child: XMLNode) -> Dictionary:
+            return child.to_dict()
+    )
 
     return output
 

--- a/addons/godot_xml/xml_node.gd
+++ b/addons/godot_xml/xml_node.gd
@@ -29,7 +29,7 @@ const KNOWN_PROPERTIES: Array[String] = ["name", "attributes", "content", "cdata
 ## Content is set as [code]__content__: content[/code].
 ## CDATA is set as [code]__cdata__: [cdata, ...][/code].
 ## Attributes are set as [code]attrs: {attr_name: attr_value}[/code].
-## Children are set as [code]children: {child_name: child_dict}[/code].
+## Children are set as [code]children: [child_dict, ...][/code].
 func to_dict() -> Dictionary:
     var output := {}
 


### PR DESCRIPTION
## Overview
This Pull Request aims to fix the issue #29, which was being caused when trying to convert a `XMLNode` to a `Dictionary` using the [`XMLNode.to_dict()`](https://github.com/elenakrittik/GodotXML/blob/26c87931d71bcc0e62a23499eb051146e3ca0c50/addons/godot_xml/xml_node.gd#L33) method. This Issue consisted of the loss of child `XMLNodes` with the same tag name. This was caused because the `"children"` field of the resultant `Dictionary` was a `Dictionary` with keys equal to the children node tag names, which may be repeated across multiple children. This was fixed by making that `"children"` field return an `Array` instead, with each child `Dictionary` stored in one of its slots.

## Related Issues
fixes #29 

## What was changed
The only parts of the code changed in this PR were the `XMLNode.to_dict()` method, which now returns a `Dictionary` with a slightly different structure. The reason for this change is explained on the Overview above. The documentation comment of the `to_dict()` method was also updated to reflect its new behavior.
Below are some snippets of how this PR changes the `to_dict` return.

### Input XML
``` xml
<?xml version="1.0" encoding="UTF-8" ?>
<methods>
	<method name="get_variable"></method>
	<method name="_static_init"></method>
</methods>
```

### Output before this PR (one of the `method` elements were lost)
``` json
{
	"__cdata__": [],
	"__content__": "",
	"__name__": "methods",
	"attrs": {

	},
	"children": {
		"method": {
			"__cdata__": [],
			"__content__": "",
			"__name__": "method",
			"attrs": {
				"name": "_static_init"
			},
			"children": {

			}
		}
	}
}
```

### Output after this PR (all the `method` elements are kept, but they are stored in an `Array`)
``` json
{
	"__cdata__": [],
	"__content__": "",
	"__name__": "methods",
	"attrs": {

	},
	"children": [
		{
			"__cdata__": [],
			"__content__": "",
			"__name__": "method",
			"attrs": {
				"name": "get_variable"
			},
			"children": []
		},
		{
			"__cdata__": [],
			"__content__": "",
			"__name__": "method",
			"attrs": {
				"name": "_static_init"
			},
			"children": []
		}
	]
}
```