### PR TITLE
Created child fetching methods

### DIFF
--- a/addons/godot_xml/xml_node.gd
+++ b/addons/godot_xml/xml_node.gd
@@ -27,8 +27,7 @@ const KNOWN_PROPERTIES: Array[String] = ["name", "attributes", "content", "cdata
 
 # Helper method to tell whether an index is valid for access in
 # the children property.
-func _child_idx_exists(idx: int) -> bool:
-    return idx >= 0 and idx < children.size()
+func _child_idx_exists(idx: int) -> bool: return idx >= 0 and idx < children.size()
 
 
 ## Returns an [Array] of children [XMLNode]s whose tag matches [param name].

--- a/addons/godot_xml/xml_node.gd
+++ b/addons/godot_xml/xml_node.gd
@@ -25,6 +25,8 @@ var _node_props_initialized: bool = false
 const KNOWN_PROPERTIES: Array[String] = ["name", "attributes", "content", "cdata", "standalone", "children"]
 
 
+# Helper method to tell whether an index is valid for access in
+# the children property.
 func _child_idx_exists(idx: int) -> bool:
     return idx >= 0 and idx < children.size()
 

--- a/addons/godot_xml/xml_node.gd
+++ b/addons/godot_xml/xml_node.gd
@@ -138,7 +138,7 @@ func _get(property: StringName):
         property not in KNOWN_PROPERTIES
         and property in self._node_props
     ):
-        var child: XMLNode = get_child_by_name(property)
+        var child := self.get_child_by_name(property)
         
         if child != null:
             return child

--- a/addons/godot_xml/xml_node.gd
+++ b/addons/godot_xml/xml_node.gd
@@ -29,6 +29,8 @@ func _child_idx_exists(idx: int) -> bool:
     return idx >= 0 and idx < children.size()
 
 
+## Returns an [Array] with all the children of this [XMLNode]
+## that match their tag names with the [param name] parameter.[br]
 func get_children_by_name(name: String) -> Array[XMLNode]:
     var result: Array[XMLNode] = []
     

--- a/addons/godot_xml/xml_node.gd
+++ b/addons/godot_xml/xml_node.gd
@@ -24,6 +24,9 @@ var _node_props: Array
 var _node_props_initialized: bool = false
 const KNOWN_PROPERTIES: Array[String] = ["name", "attributes", "content", "cdata", "standalone", "children"]
 
+func _child_idx_exists(idx: int) -> bool:
+    return idx >= 0 and idx < children.size()
+
 func get_children_by_name(name: String) -> Array[XMLNode]:
     var result: Array[XMLNode] = []
     
@@ -32,6 +35,12 @@ func get_children_by_name(name: String) -> Array[XMLNode]:
             result.append(child)
     
     return result
+
+func get_child_by_idx(idx: int) -> XMLNode:
+    if not _child_idx_exists(idx):
+        return null
+    
+    return children[idx]
 
 ## Converts this node (and all of it's children) into a [Dictionary].
 ## Name is set as [code]__name__: name[/code].

--- a/addons/godot_xml/xml_node.gd
+++ b/addons/godot_xml/xml_node.gd
@@ -42,6 +42,16 @@ func get_child_by_idx(idx: int) -> XMLNode:
     
     return children[idx]
 
+func get_child_by_name(name: String) -> XMLNode:
+    var idx: int = -1
+    
+    for i: int in children.size():
+        if children[i].name == name:
+            idx = i
+            break
+    
+    return get_child_by_idx(idx)
+
 ## Converts this node (and all of it's children) into a [Dictionary].
 ## Name is set as [code]__name__: name[/code].
 ## Content is set as [code]__content__: content[/code].

--- a/addons/godot_xml/xml_node.gd
+++ b/addons/godot_xml/xml_node.gd
@@ -43,14 +43,11 @@ func get_child_by_idx(idx: int) -> XMLNode:
     return children[idx]
 
 func get_child_by_name(name: String) -> XMLNode:
-    var idx: int = -1
+    for child: XMLNode in children:
+        if child.name == name:
+            return child
     
-    for i: int in children.size():
-        if children[i].name == name:
-            idx = i
-            break
-    
-    return get_child_by_idx(idx)
+    return null
 
 ## Converts this node (and all of it's children) into a [Dictionary].
 ## Name is set as [code]__name__: name[/code].

--- a/addons/godot_xml/xml_node.gd
+++ b/addons/godot_xml/xml_node.gd
@@ -46,6 +46,9 @@ func get_child_by_idx(idx: int) -> XMLNode:
     return children[idx]
 
 
+## Returns the first child of this [XMLNode] that matches its tag name with
+## the [param name] parameter.[br]
+## If such child isn't found, [code]null[/code] is returned.
 func get_child_by_name(name: String) -> XMLNode:
     for child: XMLNode in children:
         if child.name == name:

--- a/addons/godot_xml/xml_node.gd
+++ b/addons/godot_xml/xml_node.gd
@@ -33,13 +33,7 @@ func _child_idx_exists(idx: int) -> bool:
 
 ## Returns an [Array] of children [XMLNode]s whose tag matches [param name].
 func get_children_by_name(name: String) -> Array[XMLNode]:
-    var result: Array[XMLNode] = []
-    
-    for child: XMLNode in children:
-        if child.name == name:
-            result.append(child)
-    
-    return result
+    return self.children.filter(func(child: XMLNode): return child.name == name)
 
 
 ## A safe alternative to directly indexing into [member XMLNode.children]. Returns the node at [param idx] or `null` if it's out of bounds.

--- a/addons/godot_xml/xml_node.gd
+++ b/addons/godot_xml/xml_node.gd
@@ -140,8 +140,7 @@ func _get(property: StringName):
     ):
         var child := self.get_child_by_name(property)
         
-        if child != null:
-            return child
+        return child
 
 
 # Dotted access via editor

--- a/addons/godot_xml/xml_node.gd
+++ b/addons/godot_xml/xml_node.gd
@@ -39,6 +39,11 @@ func get_children_by_name(name: String) -> Array[XMLNode]:
     return result
 
 
+## Returns the child of this [XMLNode] that has its index matching
+## the [param idx] parameter.[br]
+## If such child isn't found, [code]null[/code] is returned.[br]
+## Note that indexes start from [code]0[/code].[br]
+## If an invalid index is passed, [code]null[/code] is returned.
 func get_child_by_idx(idx: int) -> XMLNode:
     if not _child_idx_exists(idx):
         return null

--- a/addons/godot_xml/xml_node.gd
+++ b/addons/godot_xml/xml_node.gd
@@ -24,8 +24,10 @@ var _node_props: Array
 var _node_props_initialized: bool = false
 const KNOWN_PROPERTIES: Array[String] = ["name", "attributes", "content", "cdata", "standalone", "children"]
 
+
 func _child_idx_exists(idx: int) -> bool:
     return idx >= 0 and idx < children.size()
+
 
 func get_children_by_name(name: String) -> Array[XMLNode]:
     var result: Array[XMLNode] = []
@@ -36,11 +38,13 @@ func get_children_by_name(name: String) -> Array[XMLNode]:
     
     return result
 
+
 func get_child_by_idx(idx: int) -> XMLNode:
     if not _child_idx_exists(idx):
         return null
     
     return children[idx]
+
 
 func get_child_by_name(name: String) -> XMLNode:
     for child: XMLNode in children:
@@ -48,6 +52,7 @@ func get_child_by_name(name: String) -> XMLNode:
             return child
     
     return null
+
 
 ## Converts this node (and all of it's children) into a [Dictionary].
 ## Name is set as [code]__name__: name[/code].

--- a/addons/godot_xml/xml_node.gd
+++ b/addons/godot_xml/xml_node.gd
@@ -31,8 +31,7 @@ func _child_idx_exists(idx: int) -> bool:
     return idx >= 0 and idx < children.size()
 
 
-## Returns an [Array] with all the children of this [XMLNode]
-## that match their tag names with the [param name] parameter.[br]
+## Returns an [Array] of children [XMLNode]s whose tag matches [param name].
 func get_children_by_name(name: String) -> Array[XMLNode]:
     var result: Array[XMLNode] = []
     
@@ -43,11 +42,7 @@ func get_children_by_name(name: String) -> Array[XMLNode]:
     return result
 
 
-## Returns the child of this [XMLNode] that has its index matching
-## the [param idx] parameter.[br]
-## If such child isn't found, [code]null[/code] is returned.[br]
-## Note that indexes start from [code]0[/code].[br]
-## If an invalid index is passed, [code]null[/code] is returned.
+## A safe alternative to directly indexing into [member XMLNode.children]. Returns the node at [param idx] or `null` if it's out of bounds.
 func get_child_by_idx(idx: int) -> XMLNode:
     if not _child_idx_exists(idx):
         return null
@@ -55,9 +50,7 @@ func get_child_by_idx(idx: int) -> XMLNode:
     return children[idx]
 
 
-## Returns the first child of this [XMLNode] that matches its tag name with
-## the [param name] parameter.[br]
-## If such child isn't found, [code]null[/code] is returned.
+## Returns the first child [XMLNode] whose tag matches [param name].
 func get_child_by_name(name: String) -> XMLNode:
     for child: XMLNode in children:
         if child.name == name:

--- a/addons/godot_xml/xml_node.gd
+++ b/addons/godot_xml/xml_node.gd
@@ -25,11 +25,6 @@ var _node_props_initialized: bool = false
 const KNOWN_PROPERTIES: Array[String] = ["name", "attributes", "content", "cdata", "standalone", "children"]
 
 
-# Helper method to tell whether an index is valid for access in
-# the children property.
-func _child_idx_exists(idx: int) -> bool: return idx >= 0 and idx < children.size()
-
-
 ## Returns an [Array] of children [XMLNode]s whose tag matches [param name].
 func get_children_by_name(name: String) -> Array[XMLNode]:
     return self.children.filter(func(child: XMLNode): return child.name == name)
@@ -37,7 +32,7 @@ func get_children_by_name(name: String) -> Array[XMLNode]:
 
 ## A safe alternative to directly indexing into [member XMLNode.children]. Returns the node at [param idx] or `null` if it's out of bounds.
 func get_child_by_idx(idx: int) -> XMLNode:
-    if not _child_idx_exists(idx):
+    if not (idx >= 0 and idx < children.size()):
         return null
     
     return children[idx]

--- a/addons/godot_xml/xml_node.gd
+++ b/addons/godot_xml/xml_node.gd
@@ -24,6 +24,15 @@ var _node_props: Array
 var _node_props_initialized: bool = false
 const KNOWN_PROPERTIES: Array[String] = ["name", "attributes", "content", "cdata", "standalone", "children"]
 
+func get_children_by_name(name: String) -> Array[XMLNode]:
+    var result: Array[XMLNode] = []
+    
+    for child: XMLNode in children:
+        if child.name == name:
+            result.append(child)
+    
+    return result
+
 ## Converts this node (and all of it's children) into a [Dictionary].
 ## Name is set as [code]__name__: name[/code].
 ## Content is set as [code]__content__: content[/code].

--- a/addons/godot_xml/xml_node.gd
+++ b/addons/godot_xml/xml_node.gd
@@ -134,9 +134,10 @@ func _get(property: StringName):
         property not in KNOWN_PROPERTIES
         and property in self._node_props
     ):
-        for child in self.children:
-            if child.name == property:
-                return child
+        var child: XMLNode = get_child_by_name(property)
+        
+        if child != null:
+            return child
 
 
 # Dotted access via editor


### PR DESCRIPTION
## Overview
This Pull Request brings some additions and small modifications to the `XMLNode` class with the purpose of providing easy access to children nodes in a documented way, essentially implementing what's described in the issue #34.

## Related Issues
closes #34 

## Checklist
- [x] I have tested my changes in Godot 4.2.2.
- [x] I have updated the documentation.

## What was changed
There were added three public new methods: the `get_children_by_name`, `get_child_by_idx` and `get_child_by_name`. The functionality of those methods was also added above them through doc comments. Besides those, this PR also adds the `_child_idx_exists` method, which is a private method that serves as a quick way to know if an index is valid when accessing the `children` `Array`. This is used by the `get_child_by_idx` method in order to avoid potential index out of bounds errors when trying to fetch a child with an arbitrary index.

Furthermore, this PR also refactors the `_get` method so that it now uses the new `get_child_by_name` method, which helps decreasing repeated code.
